### PR TITLE
Template refactor for overriding theme styles

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -120,10 +120,12 @@
           href="{{ 'assets/stylesheets/palette.css' | url }}"
         />
       {% endif %}
-
-      <!-- Custom icons -->
-      {% include "partials/icons.html" %}
     {% endblock %}
+
+    <!-- Custom admonitions -->
+    {% include "partials/admonitions.html" %}
+    <!-- Custom icons -->
+    {% include "partials/icons.html" %}
 
     <!-- JavaScript libraries -->
     {% block libs %}

--- a/src/templates/partials/admonitions.html
+++ b/src/templates/partials/admonitions.html
@@ -1,0 +1,56 @@
+<!--
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Custom admonition icons and colors -->
+{% set default_types = ["note", "abstract", "info", "tip", "success", "question", "warning", "failure", "danger", "bug", "example", "quote"] %}
+{% if config.theme.admonition %}
+  {% set _ = namespace(root = "", classes = "") %}
+
+  {% for type, keys in config.theme.admonition | items %}
+    {# ------------- root ------------- #}
+    {% if keys.icon %}
+      {% import ".icons/" ~ keys.icon ~ ".svg" as icon %}
+      {% set _.root = _.root ~ "--md-admonition-icon--" ~ type ~ ":url('data:image/svg+xml;charset=utf-8," ~ icon | replace("\n", "") | urlencode ~ "');" %}
+    {% endif %}
+
+    {% if keys.color %}
+      {% set _.root = _.root ~ "--md-admonition-color--" ~ type ~ ":" ~ keys.color ~ ";" %}
+    {% endif %}
+
+    {# ------------- class-specific rules ------------- #}
+    {% if type not in default_types %}
+      {% set rules = "" %}
+      {% if keys.icon %}
+        {% set rules = rules ~ "--md-admonition-icon:var(--md-admonition-icon--" ~ type ~ ");" %}
+      {% endif %}
+
+      {% if keys.color %}
+        {% set rules = rules ~ "--md-admonition-color:var(--md-admonition-color--" ~ type ~ ");" %}
+      {% endif %}
+
+      {% set _.classes = _.classes ~ ".md-typeset .admonition." ~ type ~ ",.md-typeset details." ~ type ~ "{" ~ rules ~ "}" %}
+    {% endif %}
+  {% endfor %}
+
+  {% set _.root = ":root{" ~ _.root ~ "}" %}
+  {{ ("\u003cstyle\u003e" ~ _.root ~ _.classes ~ "\u003c/style\u003e") | safe }}
+{% endif %}

--- a/src/templates/partials/icons.html
+++ b/src/templates/partials/icons.html
@@ -20,41 +20,6 @@
   IN THE SOFTWARE.
 -->
 
-<!-- Custom admonition icons -->
-{% set default_types = ["note", "abstract", "info", "tip", "success", "question", "warning", "failure", "danger", "bug", "example", "quote"] %}
-{% if config.theme.admonition %}
-  {% set _ = namespace(root = "", classes = "") %}
-
-  {% for type, keys in config.theme.admonition | items %}
-    {# ------------- root ------------- #}
-    {% if keys.icon %}
-      {% import ".icons/" ~ keys.icon ~ ".svg" as icon %}
-      {% set _.root = _.root ~ "--md-admonition-icon--" ~ type ~ ":url('data:image/svg+xml;charset=utf-8," ~ icon | replace("\n", "") | urlencode ~ "');" %}
-    {% endif %}
-
-    {% if keys.color %}
-      {% set _.root = _.root ~ "--md-admonition-color--" ~ type ~ ":" ~ keys.color ~ ";" %}
-    {% endif %}
-
-    {# ------------- class-specific rules ------------- #}
-    {% if type not in default_types %}
-      {% set rules = "" %}
-      {% if keys.icon %}
-        {% set rules = rules ~ "--md-admonition-icon:var(--md-admonition-icon--" ~ type ~ ");" %}
-      {% endif %}
-
-      {% if keys.color %}
-        {% set rules = rules ~ "--md-admonition-color:var(--md-admonition-color--" ~ type ~ ");" %}
-      {% endif %}
-
-      {% set _.classes = _.classes ~ ".md-typeset .admonition." ~ type ~ ",.md-typeset details." ~ type ~ "{" ~ rules ~ "}" %}
-    {% endif %}
-  {% endfor %}
-
-  {% set _.root = ":root{" ~ _.root ~ "}" %}
-  {{ ("\u003cstyle\u003e" ~ _.root ~ _.classes ~ "\u003c/style\u003e") | safe }}
-{% endif %}
-
 <!-- Custom annotation icon -->
 {% if config.theme.icon.annotation %}
   {% set _ = namespace(style = "\u003cstyle\u003e:root{") %}


### PR DESCRIPTION
This PR updates [src/templates/base.html](https://github.com/jaywhj/mkdocs-materialx/blob/main/src/templates/base.html) to move config-based admonition and icons customizations out of styles block.

Also, moves the logic of config-based admonitions into a separate partial.

This allows to extend this theme's CSS styles and preserve config-based customizations.

- https://github.com/jaywhj/mkdocs-materialx/discussions/28